### PR TITLE
feat: 实现读取所有版本行数据的 scan 策略

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5612,7 +5612,7 @@ dependencies = [
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#e9b045a0bdf83bd96827751ad7b3c82b1f1bb334"
+source = "git+https://github.com/Long-Live-the-DoDo/tipb.git#13de41190e3732d8435f9fb2f0f78a08fff2cb13"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ tikv_util = { path = "components/tikv_util", default-features = false }
 collections = { path = "components/collections" }
 coprocessor_plugin_api = { path = "components/coprocessor_plugin_api" }
 time = "0.1"
-tipb = { git = "https://github.com/pingcap/tipb.git" }
+tipb = { git = "https://github.com/Long-Live-the-DoDo/tipb.git" }
 tokio = { version = "1.12", features = ["full"] }
 tokio-timer = "0.2"
 tokio-openssl = "0.6"

--- a/components/test_backup/src/lib.rs
+++ b/components/test_backup/src/lib.rs
@@ -308,6 +308,7 @@ impl TestSuite {
             scan_backward_in_range: false,
             is_key_only: false,
             is_scanned_range_aware: false,
+            need_mvcc: false,
         });
         let digest = crc64fast::Digest::new();
         while let Some((k, v)) = scanner.next().unwrap() {

--- a/components/test_coprocessor/Cargo.toml
+++ b/components/test_coprocessor/Cargo.toml
@@ -24,7 +24,7 @@ tidb_query_common = { path = "../tidb_query_common", default-features = false }
 tikv = { path = "../../", default-features = false }
 tikv_util = { path = "../tikv_util", default-features = false }
 collections = { path = "../collections" }
-tipb = { git = "https://github.com/pingcap/tipb.git" }
+tipb = { git = "https://github.com/Long-Live-the-DoDo/tipb.git" }
 txn_types = { path = "../txn_types", default-features = false }
 concurrency_manager = { path = "../concurrency_manager", default-features = false }
 resource_metering = { path = "../resource_metering" }

--- a/components/tidb_query_aggr/Cargo.toml
+++ b/components/tidb_query_aggr/Cargo.toml
@@ -12,7 +12,7 @@ tidb_query_datatype = { path = "../tidb_query_datatype", default-features = fals
 tidb_query_common = { path = "../tidb_query_common", default-features = false }
 tidb_query_expr = { path = "../tidb_query_expr", default-features = false }
 tikv_util = { path = "../tikv_util", default-features = false }
-tipb = { git = "https://github.com/pingcap/tipb.git" }
+tipb = { git = "https://github.com/Long-Live-the-DoDo/tipb.git" }
 
 [dev-dependencies]
 panic_hook = { path = "../panic_hook" }

--- a/components/tidb_query_common/src/storage/mod.rs
+++ b/components/tidb_query_common/src/storage/mod.rs
@@ -22,6 +22,7 @@ pub trait Storage: Send {
         &mut self,
         is_backward_scan: bool,
         is_key_only: bool,
+        need_mvcc: bool,
         range: IntervalRange,
     ) -> Result<()>;
 
@@ -43,9 +44,10 @@ impl<T: Storage + ?Sized> Storage for Box<T> {
         &mut self,
         is_backward_scan: bool,
         is_key_only: bool,
+        need_mvcc: bool,
         range: IntervalRange,
     ) -> Result<()> {
-        (**self).begin_scan(is_backward_scan, is_key_only, range)
+        (**self).begin_scan(is_backward_scan, is_key_only, need_mvcc, range)
     }
 
     fn scan_next(&mut self) -> Result<Option<OwnedKvPair>> {

--- a/components/tidb_query_common/src/storage/test_fixture.rs
+++ b/components/tidb_query_common/src/storage/test_fixture.rs
@@ -54,6 +54,7 @@ impl super::Storage for FixtureStorage {
         &mut self,
         is_backward_scan: bool,
         is_key_only: bool,
+        _: bool,
         range: IntervalRange,
     ) -> Result<()> {
         let data_view = self

--- a/components/tidb_query_datatype/Cargo.toml
+++ b/components/tidb_query_datatype/Cargo.toml
@@ -31,7 +31,7 @@ slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global
 thiserror = "1.0"
 tikv_util = { path = "../tikv_util", default-features = false }
 collections = { path = "../collections" }
-tipb = { git = "https://github.com/pingcap/tipb.git" }
+tipb = { git = "https://github.com/Long-Live-the-DoDo/tipb.git" }
 static_assertions = { version = "1.0", features = ["nightly"] }
 tidb_query_common = { path = "../tidb_query_common", default-features = false }
 tikv_alloc = { path = "../tikv_alloc" }

--- a/components/tidb_query_datatype/src/codec/table.rs
+++ b/components/tidb_query_datatype/src/codec/table.rs
@@ -42,6 +42,12 @@ pub const INDEX_VALUE_RESTORED_DATA_FLAG: u8 = crate::codec::row::v2::CODEC_VERS
 /// ID for partition column, see <https://github.com/pingcap/parser/pull/1010>
 pub const EXTRA_PARTITION_ID_COL_ID: i64 = -2;
 
+/// ID for _tidb_mvcc_ts
+pub const EXTRA_MVCC_TS_COL_ID: i64 = -3;
+
+/// ID for _tidb_mvcc_op
+pub const EXTRA_MVCC_OP_COL_ID: i64 = -4;
+
 /// `TableEncoder` encodes the table record/index prefix.
 trait TableEncoder: NumberEncoder {
     fn append_table_record_prefix(&mut self, table_id: i64) -> Result<()> {

--- a/components/tidb_query_executors/Cargo.toml
+++ b/components/tidb_query_executors/Cargo.toml
@@ -21,7 +21,7 @@ tidb_query_aggr = { path = "../tidb_query_aggr", default-features = false }
 tikv_util = { path = "../tikv_util", default-features = false }
 log_wrappers = { path = "../log_wrappers" }
 collections = { path = "../collections" }
-tipb = { git = "https://github.com/pingcap/tipb.git" }
+tipb = { git = "https://github.com/Long-Live-the-DoDo/tipb.git" }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 itertools = "0.10"
 

--- a/components/tidb_query_executors/src/index_scan_executor.rs
+++ b/components/tidb_query_executors/src/index_scan_executor.rs
@@ -126,6 +126,7 @@ impl<S: Storage> BatchIndexScanExecutor<S> {
             is_key_only: false,
             accept_point_range: unique,
             is_scanned_range_aware,
+            need_mvcc: false,
         })?;
         Ok(Self(wrapper))
     }

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -187,6 +187,7 @@ pub fn build_executors<S: Storage + 'static>(
                     descriptor.get_desc(),
                     is_scanned_range_aware,
                     primary_prefix_column_ids,
+                    descriptor.get_need_mvcc(),
                 )?
                 .collect_summary(summary_slot_index),
             );

--- a/components/tidb_query_executors/src/table_scan_executor.rs
+++ b/components/tidb_query_executors/src/table_scan_executor.rs
@@ -42,6 +42,7 @@ impl<S: Storage> BatchTableScanExecutor<S> {
         is_backward: bool,
         is_scanned_range_aware: bool,
         primary_prefix_column_ids: Vec<i64>,
+        need_mvcc: bool,
     ) -> Result<Self> {
         let is_column_filled = vec![false; columns_info.len()];
         let mut is_key_only = true;
@@ -97,6 +98,7 @@ impl<S: Storage> BatchTableScanExecutor<S> {
             is_key_only,
             accept_point_range: no_common_handle,
             is_scanned_range_aware,
+            need_mvcc,
         })?;
         Ok(Self(wrapper))
     }

--- a/components/tidb_query_executors/src/util/scan_executor.rs
+++ b/components/tidb_query_executors/src/util/scan_executor.rs
@@ -56,6 +56,7 @@ pub struct ScanExecutorOptions<S, I> {
     pub is_key_only: bool,
     pub accept_point_range: bool,
     pub is_scanned_range_aware: bool,
+    pub need_mvcc: bool,
 }
 
 impl<S: Storage, I: ScanExecutorImpl> ScanExecutor<S, I> {
@@ -68,6 +69,7 @@ impl<S: Storage, I: ScanExecutorImpl> ScanExecutor<S, I> {
             is_key_only,
             accept_point_range,
             is_scanned_range_aware,
+            need_mvcc,
         }: ScanExecutorOptions<S, I>,
     ) -> Result<Self> {
         tidb_query_datatype::codec::table::check_table_ranges(&key_ranges)?;
@@ -85,6 +87,7 @@ impl<S: Storage, I: ScanExecutorImpl> ScanExecutor<S, I> {
                 scan_backward_in_range: is_backward,
                 is_key_only,
                 is_scanned_range_aware,
+                need_mvcc,
             }),
             is_ended: false,
         })

--- a/components/tidb_query_expr/Cargo.toml
+++ b/components/tidb_query_expr/Cargo.toml
@@ -27,7 +27,7 @@ tidb_query_codegen = { path = "../tidb_query_codegen" }
 tidb_query_datatype = { path = "../tidb_query_datatype", default-features = false }
 tidb_query_common = { path = "../tidb_query_common", default-features = false }
 tikv_util = { path = "../tikv_util", default-features = false }
-tipb = { git = "https://github.com/pingcap/tipb.git" }
+tipb = { git = "https://github.com/Long-Live-the-DoDo/tipb.git" }
 twoway = "0.2.0"
 uuid = { version = "0.8.1", features = ["v4"] }
 static_assertions = { version = "1.0", features = ["nightly"] }

--- a/components/tipb_helper/Cargo.toml
+++ b/components/tipb_helper/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 [dependencies]
 codec = { path = "../codec", default-features = false }
 tidb_query_datatype = { path = "../tidb_query_datatype", default-features = false }
-tipb = { git = "https://github.com/pingcap/tipb.git" }
+tipb = { git = "https://github.com/Long-Live-the-DoDo/tipb.git" }

--- a/components/txn_types/src/write.rs
+++ b/components/txn_types/src/write.rs
@@ -1,6 +1,7 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
 use codec::prelude::NumberDecoder;
+use std::fmt;
 use std::mem::size_of;
 use tikv_util::codec::number::{self, NumberEncoder, MAX_VAR_U64_LEN};
 
@@ -15,6 +16,12 @@ pub enum WriteType {
     Delete,
     Lock,
     Rollback,
+}
+
+impl fmt::Display for WriteType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 const FLAG_PUT: u8 = b'P';

--- a/src/coprocessor/checksum.rs
+++ b/src/coprocessor/checksum.rs
@@ -48,6 +48,7 @@ impl<S: Snapshot> ChecksumContext<S> {
             scan_backward_in_range: false,
             is_key_only: false,
             is_scanned_range_aware: false,
+            need_mvcc: false,
         });
         Ok(Self { req, scanner })
     }

--- a/src/coprocessor/dag/storage_impl.rs
+++ b/src/coprocessor/dag/storage_impl.rs
@@ -40,6 +40,7 @@ impl<S: Store> Storage for TiKVStorage<S> {
         &mut self,
         is_backward_scan: bool,
         is_key_only: bool,
+        need_mvcc: bool,
         range: IntervalRange,
     ) -> QEResult<()> {
         if let Some(scanner) = &mut self.scanner {
@@ -55,6 +56,7 @@ impl<S: Store> Storage for TiKVStorage<S> {
             self.store
                 .scanner(
                     is_backward_scan,
+                    need_mvcc,
                     is_key_only,
                     self.met_newer_ts_data_backlog == NewerTsCheckState::NotMetYet,
                     lower,

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -227,6 +227,7 @@ impl<S: Snapshot> RequestHandler for AnalyzeContext<S> {
                     scan_backward_in_range: false,
                     is_key_only: true,
                     is_scanned_range_aware: false,
+                    need_mvcc: false,
                 });
                 let res = AnalyzeContext::handle_index(
                     req,
@@ -326,6 +327,7 @@ impl<S: Snapshot> RowSampleBuilder<S> {
             false,
             false, // Streaming mode is not supported in Analyze request, always false here
             req.take_primary_prefix_column_ids(),
+            false,
         )?;
         Ok(Self {
             data: table_scanner,
@@ -794,6 +796,7 @@ impl<S: Snapshot> SampleBuilder<S> {
             false,
             false, // Streaming mode is not supported in Analyze request, always false here
             req.take_primary_prefix_column_ids(),
+            false,
         )?;
         Ok(Self {
             data: table_scanner,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1057,8 +1057,14 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                         false,
                     );
 
-                    let mut scanner =
-                        snap_store.scanner(reverse_scan, key_only, false, start_key, end_key)?;
+                    let mut scanner = snap_store.scanner(
+                        reverse_scan,
+                        false,
+                        key_only,
+                        false,
+                        start_key,
+                        end_key,
+                    )?;
                     let res = scanner.scan(limit, sample_step);
 
                     let statistics = scanner.take_statistics();

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -38,6 +38,7 @@ pub trait Store: Send {
     fn scanner(
         &self,
         desc: bool,
+        need_mvcc: bool,
         key_only: bool,
         check_has_newer_ts_data: bool,
         lower_bound: Option<Key>,
@@ -353,6 +354,7 @@ impl<S: Snapshot> Store for SnapshotStore<S> {
     fn scanner(
         &self,
         desc: bool,
+        need_mvcc: bool,
         key_only: bool,
         check_has_newer_ts_data: bool,
         lower_bound: Option<Key>,
@@ -362,6 +364,7 @@ impl<S: Snapshot> Store for SnapshotStore<S> {
         self.verify_range(&lower_bound, &upper_bound)?;
         let scanner = ScannerBuilder::new(self.snapshot.clone(), self.start_ts)
             .desc(desc)
+            .need_mvcc(need_mvcc)
             .range(lower_bound, upper_bound)
             .omit_value(key_only)
             .fill_cache(self.fill_cache)
@@ -548,6 +551,7 @@ impl Store for FixtureStore {
     fn scanner(
         &self,
         desc: bool,
+        _: bool,
         key_only: bool,
         _: bool,
         lower_bound: Option<Key>,

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -99,7 +99,7 @@ tikv_util = { path = "../components/tikv_util", default-features = false }
 error_code = { path = "../components/error_code", default-features = false }
 collections = { path = "../components/collections" }
 file_system = { path = "../components/file_system" }
-tipb = { git = "https://github.com/pingcap/tipb.git" }
+tipb = { git = "https://github.com/Long-Live-the-DoDo/tipb.git" }
 toml = "0.5"
 txn_types = { path = "../components/txn_types", default-features = false }
 uuid = { version = "0.8.1", features = ["serde", "v4"] }

--- a/tests/benches/coprocessor_executors/table_scan/util.rs
+++ b/tests/benches/coprocessor_executors/table_scan/util.rs
@@ -48,6 +48,7 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder for BatchTableScan
             black_box(false),
             black_box(false),
             black_box(vec![]),
+            false,
         )
         .unwrap();
         // There is a step of building scanner in the first `next()` which cost time,

--- a/tests/integrations/coprocessor/test_checksum.rs
+++ b/tests/integrations/coprocessor/test_checksum.rs
@@ -80,6 +80,7 @@ fn reversed_checksum_crc64_xor<E: Engine>(store: &Store<E>, range: KeyRange) -> 
         scan_backward_in_range: true,
         is_key_only: false,
         is_scanned_range_aware: false,
+        need_mvcc: false,
     });
 
     let mut checksum = 0;


### PR DESCRIPTION
实现基于策略 `WithMvccInfoPolicy` 的 `ForwardWithMvccInfoScanner`，用于读取所有 mvcc 版本的行数据。